### PR TITLE
Update flowfs to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-view-engine",
-	"version": "14.12.6",
+	"version": "14.12.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1654,17 +1654,32 @@
 			}
 		},
 		"flowfs": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/flowfs/-/flowfs-4.0.0.tgz",
-			"integrity": "sha512-E+fiPPpjdOlpdu9+f0oFCu2tRMqTWP/6E1ky1DRCbJ/WPgnqCJen7x668GimDW3vdvUiVf5I3trlgwh56fhGMg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/flowfs/-/flowfs-5.2.0.tgz",
+			"integrity": "sha512-nSKkKXgVgS44ra4marQ3vwxMmSPzvBvhcqWrwqfBcgkNlYRKvcfHJcuvyXcrS3gYi9v14o2zDB4HAnVBlsxRGA==",
 			"requires": {
 				"bluebird": "^3.7.2",
 				"event-stream": "^4.0.1",
 				"fs-extra": "^7.0.1",
-				"glob": "^7.1.4",
+				"glob": "^7.2.0",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^1.0.4",
 				"remove": "^0.1.5"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"forever-agent": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-view-engine",
-	"version": "14.12.6",
+	"version": "14.12.7",
 	"repository": "https://github.com/svelte-view-engine/svelte-view-engine",
 	"dependencies": {
 		"@babel/core": "^7.10.4",
@@ -10,7 +10,7 @@
 		"bluebird": "^3.7.2",
 		"chokidar": "^3.0.2",
 		"core-js": "^3.6.5",
-		"flowfs": "^4.0.0",
+		"flowfs": "^5.2.0",
 		"get-port": "^5.1.1",
 		"md5": "^2.3.0",
 		"node-sass": "^5.0.0",


### PR DESCRIPTION
I have a project that specified svelte-view-engine via a `git+...` url in package.json and it failed to install because flowfs 4 isn't found so this updates the package.json to v5. Oddly specifying a normal version in package.json instead of the git url installs just fine. 